### PR TITLE
Implement GraphQL service

### DIFF
--- a/TinyTask/src/graphqlService/graphqlService.ts
+++ b/TinyTask/src/graphqlService/graphqlService.ts
@@ -1,0 +1,137 @@
+import {AuthHttp} from "angular2-jwt";
+
+import {AuthService} from "../services/auth/auth.service";
+
+export class GraphQLService {
+  private url: string = "https://tinytaskgraphql.herokuapp.com";
+
+  auth: AuthService;
+
+  constructor(private authHttp: AuthHttp) {
+  }
+
+  getTask(task_id: any): Promise<any> {
+    return this.sendPostRequest({
+      query: `{ task(_id: "${task_id}") { _id name description category createdBy { _id email displayName } assignedTo { _id email displayName } position { longitude latitude } starts payment } }`
+    }).then((data) => {
+      return data.json().data.task;
+    });
+  }
+
+  getAllTasks(): Promise<any> {
+    return this.sendPostRequest({
+      query: `{ tasks { _id name description category createdBy { _id email displayName } assignedTo { _id email displayName } position { longitude latitude } starts payment } }`
+    }).then((data) => {
+      return data.json().data.tasks;
+    });
+  }
+
+  getTaskPosition(task_id: any): Promise<any> {
+    return this.sendPostRequest({
+      query: `{ task(_id: "${task_id}") { position { longitude latitude } } }`
+    }).then((data) => {
+      return data.json().data.task.position;
+    });
+  }
+
+  getTaskBewerber(task_id: any): Promise<any> {
+    return this.sendPostRequest({
+      query: `{ applications { _id task { _id name } user { _id email displayName } } }`
+    }).then((data) => {
+      let result = [];
+
+      data.json().data.applications.forEach((it) => {
+        if (it.task._id === task_id) {
+          result.push(it);
+        }
+      });
+
+      return result;
+    });
+  }
+
+  getUser(user_id: any): Promise<any> {
+    return this.sendPostRequest({
+      query: `{ user(_id: "${user_id}") { _id email displayName picture address } }`
+    }).then((data) => {
+      return data.json().data.user;
+    });
+  }
+
+  getAllUsers(): Promise<any> {
+    return this.sendPostRequest({
+      query: `{ users { _id email displayName picture address } }`
+    }).then((data) => {
+      return data.json().data.users;
+    });
+  }
+
+  getUserRating(user_id: any): Promise<any> {
+    return this.sendPostRequest({
+      query: `{ ratings { _id assignedTo { _id displayName } task { _id name } isExecutor value comment } }`
+    }).then((data) => {
+      let result = [];
+
+      data.json().data.ratings.forEach((it) => {
+        if (it.assignedTo._id === user_id) {
+          result.push(it);
+        }
+      });
+
+      return result;
+    });
+  }
+
+  newTask(newTask: any): Promise<any> {
+    return this.sendPostRequest({
+      query: `mutation { createTask(record: { name: "${newTask.name}", description: "${newTask.description}", category: "${newTask.category}", createdBy { _id: "${newTask.createdBy._id}" } assignedTo { _id: "${newTask.assignedTo._id}" } position { longitude: ${newTask.position.longitude}, latitude: ${newTask.position.latitude} } starts: "${newTask.starts}", payment: ${newTask.payment} }) { record { _id name description category createdBy { _id email displayName } assignedTo { _id email displayName } position { longitude latitude } starts payment } } }`
+    }).then((data) => {
+      return data.json().data.record;
+    });
+  }
+
+  deleteTask(task_id: any): Promise<any> {
+    return this.sendPostRequest({
+      query: `mutation { removeTask(_id: "${task_id}") { record { _id } } }`
+    }).then((data) => {
+      return data.json().data.record;
+    });
+  }
+
+  newUser(newUser: any): Promise<any> {
+    return this.sendPostRequest({
+      query: `mutation { createUser(record: { email: "${newUser.email}", displayName: "${newUser.displayName}", picture: "${newUser.picture}", address: "${newUser.address}" }) { record { _id email displayName picture address } } }`
+    }).then((data) => {
+      return data.json().data.record;
+    });
+  }
+
+  newUserRating(newUserRating: any): Promise<any> {
+    return this.sendPostRequest({
+      query: `mutation { createRating(record: { assignedTo: { _id: "${newUserRating.assignedTo._id}" }, task: { _id: "${newUserRating.task._id}" }, isExecutor: ${newUserRating.isExecutor}, value: ${newUserRating.value}, comment: "${newUserRating.comment}" }) { record { _id assignedTo { _id displayName } task { _id name } isExecutor value comment } } }`
+    }).then((data) => {
+      return data.json().data.record;
+    });
+  }
+
+  deleteUser(user_id: any): Promise<any> {
+    return this.sendPostRequest({
+      query: `mutation { removeUser(_id: "${user_id}") { record { _id } } }`
+    }).then((data) => {
+      return data.json().data.record;
+    });
+  }
+
+  private static handleError(error: any): Promise<any> {
+    console.error('An error occurred', error);
+
+    return Promise.reject(error.message || error);
+  }
+
+  private sendPostRequest(data: any): Promise<any> {
+    return this.authHttp
+      .post(this.url, data)
+      .toPromise()
+      .catch(GraphQLService.handleError);
+  }
+}

--- a/TinyTask/src/restService/restService.ts
+++ b/TinyTask/src/restService/restService.ts
@@ -1,6 +1,8 @@
 /**
  * Created by eugen on 16.11.16.
  * changes by karstenAMF/oxanaZh
+ *
+ * DEPRICATED!! Use ../services/rest.service.ts instead!
  */
 import {Http, Headers} from '@angular/http';
 import {RequestOptions} from '@angular/http';


### PR DESCRIPTION
Ich habe mich am alten REST-Service orientiert, weil der neue REST-Service bei genauerer Betrachtung viel zu generisch und nicht praktikabel ist und dadurch nicht für eine gemeinsame Service-API sinnvoll nutzbar. Der Grund hierfür ist ganz einfach: Der neue REST-Service kapselt lediglich die HTTP-Verarbeitung und ist dabei auf eine REST-API zugeschnitten. Letzteres ist irgendwo ja auch der Sinn des Services, leider vereinfacht der zu generische Ansatz die Arbeit mit der REST-API in keinster Weise, da der Entwickler, der diesen Service nutzen will, weiterhin alle Pfade und deren Parametrisierung kennen muss, um den Service nutzen zu können. Das ist nicht besonders sinnvoll, da der Sinn eines solchen Services die Abstraktion und Kapselung von eben solchen Details ist.

**Beispiel:**
```js
let userPromise = restService.getUser(4711);
```

Hier ist direkt ersichtlich, was der Code macht und es ist keinerlei Wissen über den darunter liegenden Layer (REST-API) notwendig.

```js
let userPromise = restService.get('/users/4711');
```

Hier hingegen muss, trotz des logischen und sehr einfachen Beispiel-Aufrufes, Wissen über die darunter liegende API erworben und angewandt werden. Dieses Beispiel entspricht eher einer Low-Level-Schnittstelle als einem High-Level-Ansatz, welcher im ersten Beispiel zu finden ist. Außerdem ist im zweiten Fall der Service nicht durch einen anderen austauschbar, ohne dass entsprechende Anpassungen am umliegenden Code vorgenommen werden müssten, da bswp. GraphQL keine sich ändernden URLs als Einstiegspunkt verwendet, sondern immer dieselbe URL und die Queries/Mutations werden via POST-Request verschickt. Das wäre mit diesem Low-Level-Ansatz gar nicht umsetzbar, ohne große Teile des Codes umschreiben zu müssen.

Lieber den alten REST-Service verwenden!